### PR TITLE
updated readme to point to official Travis build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ Open XAL is designed to be a flexible application framework for developing accel
 
 
 
-.. image:: https://travis-ci.org/Eothred/openxal.png?branch=master
-   :target: https://travis-ci.org/Eothred/openxal
+.. image:: https://travis-ci.org/openxal/openxal.svg
+    :target: https://travis-ci.org/openxal/openxal
 
 .. image:: https://gitlab01.esss.lu.se/ci/projects/2/status.png?ref=master
    :target: https://gitlab01.esss.lu.se/ci/projects/2?ref=master


### PR DESCRIPTION
Note: You can add ?branch=master to the svg url to see only builds from master branch (as was done earlier, see diff)

The default behaviour is to show the latest build status from any branch.
