### PR TITLE
scenario generator fixes

### DIFF
--- a/core/src/xal/model/alg/Tracker.java
+++ b/core/src/xal/model/alg/Tracker.java
@@ -1006,7 +1006,9 @@ public abstract class Tracker implements IAlgorithm, IArchive {
         // Check if there is a starting element defined and 
         if (!this.m_bolIsStarted) {                     // we haven't started propagating yet         
                
-            if (this.getStartElementId().equals(elem.getId())) {  // reached the starting element
+            if (this.getStartElementId().equals(elem.getId()) 
+            		|| this.getStartElementId().equals("BEGIN_"+elem.getParent().getId())) {  // IL: backward compatibility with BEGIN_section markers  
+            	// reached the starting element
                 this.m_bolIsStarted = true;                
                 
             } else {                // we haven't started and we haven't reached the start element

--- a/core/src/xal/model/elem/IdealMagWedgeDipole.java
+++ b/core/src/xal/model/elem/IdealMagWedgeDipole.java
@@ -342,9 +342,9 @@ public class IdealMagWedgeDipole extends ElectromagnetSeq {
 		setFieldIndex(fld_ind0);
 		/*setDesignBendAngle(ang_bend);*/
 						
-		if (element.getPartNr() == 0) // first piece
+		if (element.isFirstSlice()) // first piece
 			setEntrPoleAngle(magnet.getEntrRotAngle() * Math.PI / 180.);
-		if (element.getParts()-1 == element.getPartNr()) // last piece					
+		if (element.isLastSlice()) // last piece					
 			setExitPoleAngle(magnet.getExitRotAngle() * Math.PI / 180.);
 	}
 

--- a/core/src/xal/model/elem/IdealMagWedgeDipole2.java
+++ b/core/src/xal/model/elem/IdealMagWedgeDipole2.java
@@ -580,9 +580,9 @@ public class IdealMagWedgeDipole2 extends ElectromagnetSeq {
         this.polEntr.setPosition(0.0);
         this.polExit.setPosition(len_sect);
                         
-        if (element.getPartNr() == 0) // first piece
+        if (element.isFirstSlice()) // first piece
             setEntrPoleAngle(magnet.getEntrRotAngle() * Math.PI / 180.);
-        if (element.getParts()-1 == element.getPartNr()) // last piece                  
+        if (element.isLastSlice()) // last piece
             setExitPoleAngle(magnet.getExitRotAngle() * Math.PI / 180.);
     }
 

--- a/core/src/xal/sim/scenario/ElementMapping.java
+++ b/core/src/xal/sim/scenario/ElementMapping.java
@@ -26,6 +26,8 @@ import xal.smf.AcceleratorSeq;
  */
 public abstract class ElementMapping {
     
+	
+	
     /*
      * Local Attributes
      */
@@ -34,7 +36,19 @@ public abstract class ElementMapping {
     //  We could an equivalence class defined by AcceleratorNode#isKindOf()  (Comparable interface)
     /** The list of hardware type identifier string to modeling element class types. */
 	protected List<Entry<String, Class<? extends IComponent>>> elementMapping = new ArrayList<>();
+	
+	/** indicates whether or not subsection axis coordinate have origin at sequence center */
+	protected boolean bolSubsectionCtrOrigin = true;  // default set for SNS
+	
 
+    /** use type outs for debugging */
+	protected boolean bolDebug = false;
+	
+	/** create center markers for thick magnets when true */
+	protected boolean bolDivMags = true;
+    
+        
+    
 	
 	/*
 	 * Base Class Requirements
@@ -175,4 +189,66 @@ public abstract class ElementMapping {
 	protected void putMap(String key, Class<? extends IComponent> value) {
 		elementMapping.add(new AbstractMap.SimpleImmutableEntry<String, Class<? extends IComponent>>(key, value));
 	}
+	
+	
+    /**
+     * Set flag to force lattice generator to place a permanent marker in the middle of every
+     * thick element.
+     * 
+     * @param halfmag <code>true</code> yes put the middle marker (default), else <code>false</code>
+     *                for no middle markers.
+     */
+    public void setDivideMagnetFlag(boolean halfMag)    {
+        this.bolDivMags = halfMag;
+    }
+    
+    /**
+     * Set flag to determine whether debugging information is sent to standard output.
+     * 
+     * @param bolDebug  <code>true</code> for debugging output, 
+     *                  else <code>false</code> to stop debugging output.
+     */
+    public void setDebug(boolean bolDebug) {
+        this.bolDebug = bolDebug;
+    }
+    
+    /*
+     * Attribute Queries
+     */
+    
+    /**
+     * If the value here is <code>true</code> then marker modeling elements are placed
+     * at the center of thick magnets when the model lattice is created.
+     * 
+     * @return the flag to force lattice generator to place a permanent marker in the middle of every
+     *         thick element.
+     */
+    public boolean isMagnetDivided()    {
+        return bolDivMags;
+    }
+    
+    /**
+     * Get the debugging flag.  If <code>true</code> then debugging
+     * information is being sent to the standard output.
+     * 
+     * @return  <code>true</code> if debugging information is being sent to standard output,
+     *          <code>false</code> when in normal operation.
+     */
+    public boolean isDebugging() {
+        return bolDebug;
+    }   
+
+    
+    /**
+     * Returns whether or the origin of the axis of subsection is at the center of the 
+     * sequence, normally it is located at the entrance of the sequence.
+     * 
+     * @return  <code>true</code> if the axis origin is at the center of the sequence,
+     *          <code>false</code> otherwise (likely at the sequence entrance)
+     *
+     * @since  Jan 29, 2015   by Christopher K. Allen
+     */
+    public boolean isSubsectionAxisOriginCentered() {
+        return bolSubsectionCtrOrigin;
+    }
 }

--- a/core/src/xal/sim/scenario/FileBasedElementMapping.java
+++ b/core/src/xal/sim/scenario/FileBasedElementMapping.java
@@ -10,6 +10,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
+import javax.swing.text.StyledEditorKit.BoldAction;
+
 import xal.model.IComponent;
 import xal.model.IComposite;
 import xal.model.Sector;
@@ -91,7 +93,12 @@ public class FileBasedElementMapping extends ElementMapping {
         FileBasedElementMapping mapHwToModElem = new FileBasedElementMapping();
 
         // Drill down to the data adaptor node containing the (hardware, model) associations 
-        DataAdaptor daCfg = daDoc.childAdaptor( "configuration" );	    
+        DataAdaptor daCfg = daDoc.childAdaptor( "configuration" );
+        
+        if (daCfg.hasAttribute("debug")) mapHwToModElem.bolDebug = daCfg.booleanValue("debug");
+        if (daCfg.hasAttribute("divMags")) mapHwToModElem.bolDivMags = daCfg.booleanValue("divMags");
+        if (daCfg.hasAttribute("subsectionCtrOrigin")) mapHwToModElem.bolSubsectionCtrOrigin = daCfg.booleanValue("subsectionCtrOrigin");
+        
         DataAdaptor daAssoc = daCfg.childAdaptor("associations");
         
         // For each map of hardware node to modeling element enter that association into the  table

--- a/core/src/xal/sim/scenario/FileBasedElementMapping.java
+++ b/core/src/xal/sim/scenario/FileBasedElementMapping.java
@@ -127,12 +127,13 @@ public class FileBasedElementMapping extends ElementMapping {
         // Get the default sequence modeling element used whenever a hardware sequence has no model counterpart
         try {
             DataAdaptor daSeq = daElements.childAdaptor("sequence");
+            if (daSeq == null) throw new ClassNotFoundException("No sequence attribute in model configuration file.");
             String      strClsNm = daSeq.stringValue("type");
 
             mapHwToModElem.setDefaultSequence(strClsNm);
             
         } catch (ClassNotFoundException e) {
-            System.err.println("ClassNotFound when loading " + urlModelConfig + ", using default sequence: " + e.getMessage());
+            System.err.println("Problem when loading " + urlModelConfig + ", using default sequence element: " + e.getMessage());
 
             mapHwToModElem.clsDefaultSeq = Sector.class;
         }
@@ -144,18 +145,20 @@ public class FileBasedElementMapping extends ElementMapping {
         
         } catch (ClassNotFoundException e) {
         
-            System.err.println("ClassNotFound when loading " + urlModelConfig + ", using default drift: " + e.getMessage());
+            System.err.println("Problem when loading " + urlModelConfig + ", using default drift: " + e.getMessage());
             mapHwToModElem.clsDriftElem = IdealDrift.class;
         }
         
         // The the element type used to represent an RF cavity drift space
         try {
             DataAdaptor   daCavDrift = daElements.childAdaptor("rfcavdrift");
+            if (daCavDrift == null) throw new ClassNotFoundException("No rfcavdrift element in model configuration file.");
             String        strClsName = daCavDrift.stringValue("type");
 
             mapHwToModElem.setRfCavityDrift(strClsName);
 
         } catch (ClassNotFoundException e) {
+            System.err.println("Problem when loading " + urlModelConfig + ", using default RF cavity drift: " + e.getMessage());
             mapHwToModElem.clsRfCavDriftElem = IdealRfCavityDrift.class;
         }
         

--- a/core/src/xal/sim/scenario/LatticeElement.java
+++ b/core/src/xal/sim/scenario/LatticeElement.java
@@ -57,35 +57,6 @@ import xal.smf.impl.Magnet;
  * @version  Sep 5, 2014
  */
 public class LatticeElement implements Comparable<LatticeElement> {
-	
-    
-    /*
-     * Global Methods
-     */
-    
-    /**
-     * Creates marker elements that should be used solely by
-     * the lattice generator (i.e., <code>LatticeSequence</code>).  There is no
-     * corresponding SMF hardware node associated to the returned element. 
-     * Since there is no associated hardware the returned element is considered 
-     * <i>artificial</i> returning <code>true</code> when 
-     * <code>{@link #isArtificial()}</code> is called.
-     *
-     * @param strName      the name identifier of the marker
-     * @param dblPos       the position of the marker in its sequence
-     * @param indSeqPos    the index of the marker element within the sequence 
-     *
-     * @return  a <i>artificial</i> lattice element representing a lattice creation marker
-     *
-     * @since  Jan 30, 2015   by Christopher K. Allen
-     */
-    public static LatticeElement    createMarker(String strName, double dblPos, int indSeqPos) {
-    
-        LatticeElement  lemMarker = new LatticeElement(strName, dblPos, indSeqPos);
-        
-        return lemMarker;
-    }
-
     /*
      * Local Attributes
      */
@@ -223,35 +194,6 @@ public class LatticeElement implements Comparable<LatticeElement> {
 		this.indNodeOrigPos = originalPosition;
 	}
 	
-	/**
-	 * Private constructor for making marker elements to be used solely by
-	 * the lattice generator (i.e., <code>LatticeSequence</code>).  This method
-	 * is called by the static method <code>createMarker()</code>.  Since there
-	 * is no associated hardware represented by this element it is considered 
-	 * <i>artificial</i> returning <code>true</code> when 
-	 * <code>{@link #isArtificial()}</code> is called.
-	 *
-	 * @param strName      the name identifier of the marker
-	 * @param dblPos       the position of the marker in its sequence
-	 * @param indSeqPos    the index of the marker element within the sequence 
-	 *
-	 * @since  Jan 30, 2015   by Christopher K. Allen
-	 */
-	private LatticeElement(String strName, double dblPos, int indSeqPos) {
-        this.strElemId = strName;
-        this.smfNode = null; 
-        this.clsModElemType = null;
-        
-        this.bolArtificalElem = true;
-                
-        this.dblElemCntrPos = dblPos;
-        this.dblElemEntrPos = dblPos;
-        this.dblElemExitPos = dblPos;
-        this.dblElemLen = 0.0;
-        
-        this.indNodeOrigPos = indSeqPos;
-	}
-
 	
 	/**
 	 * Sets the (optional) string identifier for the modeling element that
@@ -509,16 +451,6 @@ public class LatticeElement implements Comparable<LatticeElement> {
 	 * @since  Dec 4, 2014
 	 */
 	public IComponent createModelingElement() throws ModelException {
-	    
-	    // If I am an artificial I have no modeling element 
-	    if (this.isArtificial()) 
-            throw new ModelException("Tried to create a modeling element for an artificial lattice element " + this.strElemId);
-//	    {
-//	        IComponent mdlMarker = new xal.model.elem.Marker();
-//	        
-//	        mdlMarker.initializeFrom(this);
-//	        return mdlMarker;
-//	    }
 	    if (component == null) {
 			try {
 				component = clsModElemType.newInstance();		

--- a/core/src/xal/sim/scenario/LatticeElement.java
+++ b/core/src/xal/sim/scenario/LatticeElement.java
@@ -121,13 +121,13 @@ public class LatticeElement implements Comparable<LatticeElement> {
     private double dblElemLen;
     
     /** center position of the modeling element within its parent sequence */
-	private double dblElemCntrPos;
+	protected double dblElemCntrPos;
 	
 	/** axial position of the modeling element entrance */
-	private double dblElemEntrPos; 
+	protected double dblElemEntrPos; 
 	
     /** axial position of the modeling element exit */
-	private double dblElemExitPos;
+	protected double dblElemExitPos;
 	
 
 	

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -140,7 +140,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
         if (smfSeqRoot instanceof RfCavity) {
             RfCavity    seqRfCav = (RfCavity)smfSeqRoot;
             
-            this.dblCavFreq = seqRfCav.getCavFreq();
+            this.dblCavFreq = seqRfCav.getCavFreq() * 1e6;
             this.dblCavMode = seqRfCav.getStructureMode();
         } else {
             
@@ -192,7 +192,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
         if (smfSeqChild instanceof RfCavity) {
             RfCavity    seqRfCav = (RfCavity)smfSeqChild;
 
-            this.dblCavFreq = seqRfCav.getCavFreq();
+            this.dblCavFreq = seqRfCav.getCavFreq() * 1e6;
             this.dblCavMode = seqRfCav.getStructureMode();
         } else {
 

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -697,6 +697,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
                 // Now generate the lattice structure for the child sequence and all
                 //  its children
                 latSeqChild.populateLatticeSeq();
+                latSeqChild.bolCtrOrigin = true; // false for ESS, true for SNS
                 
                 // Added the populated child lattice to this lattice
                 this.addLatticeElement(latSeqChild);
@@ -785,6 +786,8 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
 
             }
                 
+            axialTranslation(-dblOffset);
+            
             this.bolCtrOrigin = false;
         }
         

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -187,7 +187,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
      * @since  Dec 12, 2014   @author Christopher K. Allen
      */
     private LatticeSequence(LatticeSequence latSeqParent, AcceleratorSeq smfSeqChild, double dblPos, int indOrgPos) {
-        super(smfSeqChild, dblPos, latSeqParent.getSequenceModelType(smfSeqChild), indOrgPos);
+        super(smfSeqChild, dblPos + smfSeqChild.getLength()/2.0, latSeqParent.getSequenceModelType(smfSeqChild), indOrgPos);
 
         this.lstLatElems = new LinkedList<>();
         this.lstSubSeqs  = new LinkedList<>();
@@ -921,7 +921,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
                 // Check if there is a collision between the current element and 
                 //  the lattice sequence.  This should not normally occur so we throw
                 //  up an exception if we find this is so.
-                if (lemCurr.getStartPosition() - lsqLast.getEndPosition() <= EPS)
+                if (lemCurr.getStartPosition() - lsqLast.getEndPosition() < -EPS)
                     throw new ModelException("Collision between a nested sequence " + 
                             lsqLast.getHardwareNode().getId() +
                             " and its parent child node " +

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -20,7 +20,6 @@ import xal.model.IComposite;
 import xal.model.IElement;
 import xal.model.Lattice;
 import xal.model.ModelException;
-import xal.model.elem.IdealRfGap;
 import xal.sim.sync.SynchronizationManager;
 import xal.smf.Accelerator;
 import xal.smf.AcceleratorNode;
@@ -513,10 +512,6 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
         //  If two thick elements intersect then we bail out with a ModelException
         this.splitSequenceElements();
         
-        // Search the sequence for all the artificial element that do not have hardware
-        //  counterparts and remove them before the modeling elements are created.
-        this.removeArtificialElements();
-        
         // Create the modeling element representing this lattice sequence.
         //  Recall that this lattice sequence must be a top-level sequence
         //  since users do not have access to the sub-lattice constructor
@@ -701,13 +696,9 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
 
             // Translate all the non-artificial element along the sequence axis
             for (LatticeElement lem : this) { 
-                
-                // If no artificial has central coordinates, so skip them
-                if (!lem.isArtificial())
-                    lem.axialTranslation(dblOffset);
-
+                lem.axialTranslation(dblOffset);
             }
-                
+            
             axialTranslation(-dblOffset);
             
             this.bolCtrOrigin = false;
@@ -728,10 +719,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
             // Now lets try to fix this. If we fail, some thick element will cover another.
             // Translate all the non-artificial element along the sequence axis
             for (LatticeElement lem : this) { 
-                
-                // If no artificial has central coordinates, so skip them
-                if (!lem.isArtificial())
-                    lem.axialTranslation(-dblBeginSeqChild);                
+                lem.axialTranslation(-dblBeginSeqChild);                
             }
             axialTranslation(dblBeginSeqChild);
             dblElemExitPos = dblElemEntrPos + (dblEndSeqChild - dblBeginSeqChild); 
@@ -968,31 +956,6 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
     }
     
     /**
-     *  Removes all the artificial lattice elements in this sequence.  These are the
-     *  lattice elements without a hardware association and were used only in the
-     *  lattice generation process.
-     *
-     * @since  Jan 30, 2015   by Christopher K. Allen
-     */
-    private void removeArtificialElements() {
-        
-        // Identify and collect all my direct childtren that are 
-        //  artificial elements.
-        List<LatticeElement>    lstElemsToRemove = new LinkedList<>();
-        
-        for (LatticeElement lem : this) 
-            if (lem.isArtificial())
-                lstElemsToRemove.add(lem);
-        
-        // Remove all the artificial element children 
-        this.removeAllLatticeElements(lstElemsToRemove);
-        
-        // Recursively remove all the artificial elements in my subsequences
-        for (LatticeSequence lsq : this.lstSubSeqs)
-            lsq.removeArtificialElements();
-    }
-
-    /**
      * <p>Visits each element and invokes conversion on it, using element mapper on it.</p>
      * <p>Hooks synchronization manager to each element.</p>
      * <p>Adds drifts between the elements.</p>
@@ -1197,18 +1160,6 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
             lem.getEndPosition() < 0
             )
             this.bolCtrOrigin = true;
-    }
-    
-    /**
-     * Removes the given <code>LatticeElement</code> from the list of such elements
-     * in this sequence.
-     * 
-     * @param lem
-     *
-     * @since  Jan 28, 2015   by Christopher K. Allen
-     */
-    private void removeLatticeElement(LatticeElement lem) {
-        this.lstLatElems.remove(lem);
     }
     
     /**

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -948,8 +948,24 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
         }
 
         // If we have a thick element left over we add it to the list of lattice elements.
-        if (lemLastThick != null)
-            addSplitElementTo(lstSplitElems, lemLastThick);          
+        if (lemLastThick != null) {
+        	if (lemLastThick instanceof LatticeSequence) {
+                // Down cast it to its true type
+                LatticeSequence lsqLast = (LatticeSequence)lemLastThick;
+
+                // Recursively split up the elements of the child sequence then add it 
+                //  to the list of split elements. Null out the last thick element.
+                lsqLast.splitSequenceElements();
+                lstSplitElems.add(lsqLast);
+                lemLastThick = null;
+            // 2) The current element lives outside the last thick element.
+            } else  {
+                // If so then add the last thick element to the list of split element and 
+                //  zero out the last thick element reference.
+                this.addSplitElementTo(lstSplitElems, lemLastThick);
+                lemLastThick = null;
+            }
+        }
 
         // Replace our list of unsplit lattice elements with the new list of split ones.
         this.lstLatElems = lstSplitElems;

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -550,7 +550,8 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
         AcceleratorSeq  smfSeqRoot = this.getHardwareNode();
         Accelerator     smfAccel   = smfSeqRoot.getAccelerator();
         
-        String  strComment = "Accelerator ID:" + smfAccel.getId() + ", "; 
+        String  strComment = "";
+        if (smfAccel != null) strComment += "Accelerator ID:" + smfAccel.getId() + ", "; 
         strComment += "Sequence ID: " + smfSeqRoot.getId() + ", ";
         strComment += "Date: " + Calendar.getInstance().getTime() + ", ";
         strComment += "Version soft type: " + smfSeqRoot.getSoftType() + ", ";

--- a/core/src/xal/sim/scenario/LatticeSequence.java
+++ b/core/src/xal/sim/scenario/LatticeSequence.java
@@ -1275,7 +1275,7 @@ public class LatticeSequence extends LatticeElement implements Iterable<LatticeE
      */
     private void addSplitElementTo(List<LatticeElement> lstSplitElems, LatticeElement latElemAddend) {
         
-        if (latElemAddend.getLength() > EPS || latElemAddend.getParts() <= 1) 
+        if (latElemAddend.getLength() > EPS || (latElemAddend.isFirstSlice() && latElemAddend.isLastSlice()))
             lstSplitElems.add(latElemAddend);
     }
     

--- a/core/src/xal/sim/scenario/Scenario.java
+++ b/core/src/xal/sim/scenario/Scenario.java
@@ -53,31 +53,11 @@ public class Scenario {
 
     /** Synchronization manager constant for synchronization only to live magnet values */
     public static final String SYNC_MODE_RF_DESIGN = "RF_DESIGN";
-	
-    
-    /*
-     * Global Variables
-     */
-    
-    /** Debugging flag - debugging type outs sent to standard output */
-    private static boolean  BOL_DEBUG = false;
     
 
     /*
      * Global Operations
      */
-    
-    /**
-     * Toggle the debugging type out feature.
-     * 
-     * @param bolDebug  if <code>true</code> debugging information is sent to standard output,
-     *                  if <code>false</code> operation is quiet
-     *
-     * @since  Jan 15, 2015   by Christopher K. Allen
-     */
-    public static void setDebugging(boolean bolDebug) {
-        BOL_DEBUG = bolDebug;
-    }
     
     /**
      * Creates a new Scenario for the supplied accelerator sequence.
@@ -93,8 +73,6 @@ public class Scenario {
         Accelerator         smfAccel      = smfSeq.getAccelerator();
         ElementMapping      mapNodeToElem = smfAccel.getElementMapping();
         ScenarioGenerator   mdlGenScnr    = new ScenarioGenerator(mapNodeToElem);
-        
-        mdlGenScnr.setDebug(BOL_DEBUG);
 
         return mdlGenScnr.generateScenario(smfSeq);
     }
@@ -111,8 +89,6 @@ public class Scenario {
 
         // We have a linear accelerator/transport line - process as such
         ScenarioGenerator mdlGenScnr = new ScenarioGenerator(mapNodeToElem);
-
-        mdlGenScnr.setDebug(BOL_DEBUG);
 
         return mdlGenScnr.generateScenario(smfSeq);
     }
@@ -134,8 +110,6 @@ public class Scenario {
         Accelerator         smfAccel      = smfRing.getAccelerator();
         ElementMapping      mapNodeToElem = smfAccel.getElementMapping();
         ScenarioGenerator   mdlGenScnr    = new ScenarioGenerator( mapNodeToElem );
-
-        mdlGenScnr.setDebug(BOL_DEBUG);
 
         return mdlGenScnr.generateScenario( smfRing ); 
     }

--- a/core/src/xal/sim/scenario/ScenarioGenerator.java
+++ b/core/src/xal/sim/scenario/ScenarioGenerator.java
@@ -63,20 +63,6 @@ class ScenarioGenerator {
 //	private AcceleratorSeq smfSequence;
 //  private SynchronizationManager syncManager;
 	
-    
-    //
-    //  Internal State
-
-    /** Flag for dividing magnets at center location and adding marker */
-	private boolean bolDivMags = true;
-	
-	/** Flag for typing out debugging information */
-	private boolean bolDebug = false;
-	
-	/** Flag for typing out debugging information verbosely */
-	private boolean bolVerbose = false;
-//	private PrintStream cout = System.out;
-	
 	
 //	/**
 //	 * Default constructor, creates an empty Lattice. Uses DefaultElementMapping.
@@ -99,64 +85,6 @@ class ScenarioGenerator {
 		this.mapNodeToModCls = elementMapping;
 //		smfSequence = aSequence;		
 	}
-
-	/**
-	 * Set flag to force lattice generator to place a permanent marker in the middle of every
-	 * thick element.
-	 * 
-	 * @param halfmag <code>true</code> yes put the middle marker (default), else <code>false</code>
-	 * for no middle markers.
-	 */
-	public void setDivideMagnetFlag(boolean halfMag)	{
-		this.bolDivMags = halfMag;
-	}
-	
-    
-    /**
-     * Set debugging output to stdout.
-     * 
-     * @param bolDebug <code>true</code> for output else <code>false</code>.
-     */
-    public void setDebug(boolean bolDebug) {
-        this.bolDebug = bolDebug;
-    }
-    
-    /**
-     * Set debugging output to bolVerbose.
-     * 
-     * @param bolVerbose <code>true</code> for bolVerbose output else <code>false</code>.
-     */
-    public void setVerbose(boolean bolVerbose) {
-        this.bolVerbose = bolVerbose;
-    }
-    
-    
-    /*
-     * Attribute Queries
-     */
-    
-	/**
-	 * @return the flag to force lattice generator to place a permanent marker in the middle of every
-	 *         thick element.
-	 */
-	public boolean isMagnetDivided()	{
-		return bolDivMags;
-	}
-	
-	/**
-	 * @return the flag for debugging output to stdout.
-	 * */
-	public boolean isDebugging() {
-		return bolDebug;
-	}	
-
-	/**
-	 * @return the flag for debugging output to bolVerbose.
-	 */
-	public boolean getVerboseFlag() {
-		return bolVerbose;
-	}
-
 	
 	/*
 	 * Operations
@@ -203,9 +131,6 @@ class ScenarioGenerator {
             
             latSeq = new LatticeSequence(smfSeq, this.mapNodeToModCls);
         }
-        
-        latSeq.setDebug( this.isDebugging() );
-        latSeq.setDivideMagnetFlag( this.isMagnetDivided() );
         
         Lattice         mdlLat = latSeq.createModelLattice(mgrSync);
         

--- a/core/test/src/xal/model/probe/traj/TestParticleProbeTrajectory.java
+++ b/core/test/src/xal/model/probe/traj/TestParticleProbeTrajectory.java
@@ -73,9 +73,6 @@ public class TestParticleProbeTrajectory {
     /** Flag used for comparing the design and production trajectories (otherwise just compute design) */
     private static final boolean        BOL_COMPARE = false;
     
-    /** Toggle lattice generator debugging output */
-    private static final boolean        BOL_LATGEN_DEBUG = false;
-    
 
     /** Location of the design accelerator configuration */
     static final private String         STR_CFGFILE_DSGN = "/site/optics/design/main.xal";
@@ -255,8 +252,6 @@ public class TestParticleProbeTrajectory {
 
         SEQ_DSGN = ACCEL_DSGN.findSequence(STR_ID_TESTSEQ);
         SEQ_PROD = ACCEL_PROD.findSequence(STR_ID_TESTSEQ);
-        
-        Scenario.setDebugging(BOL_LATGEN_DEBUG);
         
         MOD_DSGN = Scenario.newScenarioFor(SEQ_DSGN);
         MOD_DSGN.setSynchronizationMode(Scenario.SYNC_MODE_DESIGN);

--- a/core/test/src/xal/sim/run/TestCompareDesignAndProduction.java
+++ b/core/test/src/xal/sim/run/TestCompareDesignAndProduction.java
@@ -83,9 +83,6 @@ public class TestCompareDesignAndProduction {
     /** Flag used for comparing the design and production trajectories (otherwise just compute design) */
     private static final boolean        BOL_COMPARE = false;
     
-    /** Toggle lattice generator debugging output */
-    private static final boolean        BOL_LATGEN_DEBUG = false;
-    
 
     /** Location of the design accelerator configuration */
     static final private String         STR_CFGFILE_DSGN = "/site/optics/design/main.xal";
@@ -265,8 +262,7 @@ public class TestCompareDesignAndProduction {
 
         SEQ_DSGN = ACCEL_DSGN.findSequence(STR_ID_TESTSEQ);
         SEQ_PROD = ACCEL_PROD.findSequence(STR_ID_TESTSEQ);
-        
-        Scenario.setDebugging(BOL_LATGEN_DEBUG);
+
         
         MOD_DSGN = Scenario.newScenarioFor(SEQ_DSGN);
         MOD_DSGN.setSynchronizationMode(Scenario.SYNC_MODE_DESIGN);


### PR DESCRIPTION
I finally got ScenarioGenerator working again also for ESS lattice.
- Main problem was that the semantics of sequences was implicitly changed - subsequence.position became the center instead of the beginning for cavities. Fixed it by making the semantics configurable through model/scenario generator configuration file. (It seemed nice to also add debug and divide magnets flags there)
- getParts and getPartsNr code was broken and fixed with nicer implementation
- There used to be marker with "BEGIN_sectionname". setStartId doesn't support to run probe from start of a section so I added workaround.
- If there was no "sequence" attribute in model configuration file, loading failed - fixed it for backwards compatibility
- Some other minor bugs
