### PR TITLE
update readme.md build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Open XAL is designed to be a flexible application framework for developing accel
 
 Branch | Build Result
 ------ | ------------
-Open XAL Master | ![Open XAL Master Build Test](https://travis-ci.org/openxal/openxal.svg)
-ESS Master | ![ESS Build Test](https://gitlab01.esss.lu.se/ess-csr/openxal/badges/site.ess.master/build.svg)
+Open XAL Master | [![Open XAL Master Build Test](https://travis-ci.org/openxal/openxal.svg)](https://github.com/openxal/openxal)
+ESS Master | [![ESS Build Test](https://gitlab01.esss.lu.se/ess-csr/openxal/badges/site.ess.master/build.svg)](https://bitbucket.org/europeanspallationsource/openxal/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Open XAL is designed to be a flexible application framework for developing accel
 
 Branch | Build Result
 ------ | ------------
-Open XAL Master | [![Open XAL Master Build Test](https://travis-ci.org/openxal/openxal.svg)](https://github.com/openxal/openxal)
-ESS Master | [![ESS Build Test](https://gitlab01.esss.lu.se/ess-csr/openxal/badges/site.ess.master/build.svg)](https://bitbucket.org/europeanspallationsource/openxal/)
+Open XAL Master | [![Open XAL Master Build Test](https://travis-ci.org/openxal/openxal.svg)](https://travis-ci.org/openxal/openxal)
+ESS Master | [![ESS Build Test](https://gitlab01.esss.lu.se/ess-csr/openxal/badges/site.ess.master/build.svg)](https://gitlab01.esss.lu.se/ess-csr/openxal/builds)
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open XAL is designed to be a flexible application framework for developing accel
 Branch | Build Result
 ------ | ------------
 Open XAL Master | ![Open XAL Master Build Test](https://travis-ci.org/openxal/openxal.svg)
-ESS Master | ![ESS Build Test](https://gitlab01.esss.lu.se/ci/projects/2/status.png?ref=master)
+ESS Master | ![ESS Build Test](https://gitlab01.esss.lu.se/ess-csr/openxal/badges/site.ess.master/build.svg)
 
 
 


### PR DESCRIPTION
- The ESS status image was not working for others.
- The build status images now links to the respective build sites (travis and gitlab-ci)

I think it makes more sense this way. In 283691f I had made the links to the repositories on github/bitbucket but then I figured actually one is probably more curious about the test output than the sources if one is clicking on these links.

@ilist2 It would be good if the ESS one could be provided by the Jenkins instead of Gitlab-CI, do you know how to do that?
