### PR TITLE
Preconfiguring launcher's file watcher only when not loaded from a file.

### DIFF
--- a/apps/launcher/src/xal/app/launcher/FileWatcher.java
+++ b/apps/launcher/src/xal/app/launcher/FileWatcher.java
@@ -52,14 +52,11 @@ public class FileWatcher implements DataListener {
 		MODEL = model;
 		
 		_folders =  new ArrayList<File>();
-
-		// preconfigure with the default executable directories relative to the current Launcher jar
-		preConfigure();
 	}
 	
 	
 	/** preconfigure when initializing without a document file */
-	private void preConfigure() {
+	public void preConfigure() {
 		try {
 			// set the watch folder to be the directory containing the jar file that launched this application
 			final URL jarURL = getClass().getProtectionDomain().getCodeSource().getLocation();

--- a/apps/launcher/src/xal/app/launcher/LaunchModel.java
+++ b/apps/launcher/src/xal/app/launcher/LaunchModel.java
@@ -190,6 +190,7 @@ public class LaunchModel implements DataListener {
 		RULES.add( new Rule( "*.py", "Jython", "jython", "%f" ) );
 				
 		LAUNCHER.preConfigure();
+		FILE_WATCHER.preConfigure();
 		
 		refreshApplications();
 	}


### PR DESCRIPTION
Preconfiguration of launcher happened even when loading a file. This caused duplicated entries in the menu.
