### PR TITLE
M6.misalignments

### DIFF
--- a/core/src/xal/model/alg/EnvelopeBacktracker.java
+++ b/core/src/xal/model/alg/EnvelopeBacktracker.java
@@ -12,16 +12,12 @@ import xal.model.IElement;
 import xal.model.IProbe;
 import xal.model.ModelException;
 import xal.model.elem.ChargeExchangeFoil;
-import xal.model.elem.IdealMagQuad;
 import xal.model.elem.IdealRfGap;
 import xal.model.probe.EnvelopeProbe;
 import xal.model.probe.traj.EnvelopeProbeState;
-import xal.model.probe.traj.ProbeState;
 import xal.tools.beam.CovarianceMatrix;
 import xal.tools.beam.PhaseMap;
 import xal.tools.beam.PhaseMatrix;
-import xal.tools.beam.Twiss;
-import xal.tools.math.r3.R3;
 
 
 /**
@@ -367,20 +363,6 @@ public class EnvelopeBacktracker extends EnvelopeTrackerBase {
             
             // Compute the full transfer matrix for the distance dblLen
             matPhi   = matPhi1.times( matPhiSc.times(matPhi0) );
-        }
-        
-        
-        
-        if (ifcElem instanceof IdealMagQuad) {   
-            // sako  put alignment error in sigma matrix
-            //  NOTE the use of negative displacements for back-propagation
-            IdealMagQuad    elemQuad = (IdealMagQuad)ifcElem;
-            
-            double delx = - elemQuad.getAlignX();
-            double dely = - elemQuad.getAlignY();
-            double delz = - elemQuad.getAlignZ();
-            
-            matPhi = this.modTransferMatrixForDisplError(delx, dely, delz, matPhi);
         }
         
         return matPhi;

--- a/core/src/xal/model/alg/EnvelopeTracker.java
+++ b/core/src/xal/model/alg/EnvelopeTracker.java
@@ -16,12 +16,10 @@ import xal.model.IElement;
 import xal.model.IProbe;
 import xal.model.ModelException;
 import xal.model.elem.ChargeExchangeFoil;
-import xal.model.elem.IdealMagQuad;
 import xal.model.elem.IdealRfGap;
 import xal.model.elem.IdealRfGapUpgraded;
 import xal.model.probe.EnvelopeProbe;
 import xal.model.probe.traj.EnvelopeProbeState;
-import xal.model.probe.traj.ProbeState;
 import xal.tools.beam.CovarianceMatrix;
 import xal.tools.beam.PhaseMap;
 import xal.tools.beam.PhaseMatrix;
@@ -317,7 +315,7 @@ public class EnvelopeTracker extends EnvelopeTrackerBase {
 
             probe.setPosition(pos);
             probe.setCovariance(covTau1);
-            
+            // TODO update energy of the probe
             
             // space charge transfer matrix
             PhaseMatrix matPhiSc = this.compScheffMatrix(dblLen, probe, ifcElem);   
@@ -346,16 +344,6 @@ public class EnvelopeTracker extends EnvelopeTrackerBase {
             double      dphi     = this.effPhaseSpread(probe, elemRfGap);
             
             matPhi = this.modTransferMatrixForEmitGrowth(dphi, matPhi);
-        }
-        
-        if (ifcElem instanceof IdealMagQuad) {   // sako  put alignment error in sigma matrix
-            IdealMagQuad    elemQuad = (IdealMagQuad)ifcElem;
-            
-            double delx = elemQuad.getAlignX();
-            double dely = elemQuad.getAlignY();
-            double delz = elemQuad.getAlignZ();
-            
-            matPhi = this.modTransferMatrixForDisplError(delx, dely, delz, matPhi);
         }
         
         return matPhi;

--- a/core/src/xal/model/alg/EnvelopeTrackerBase.java
+++ b/core/src/xal/model/alg/EnvelopeTrackerBase.java
@@ -557,63 +557,6 @@ public abstract class EnvelopeTrackerBase extends Tracker {
 
     }
 
-    /**
-     * <h2>Add Displacement Error to Transfer Matrix</h2>
-     * <p>
-     * Method to add the effects of a spatially displaced to the
-     * beamline element represented by the given 
-     * transfer matrix.  The returned matrix is the
-     * original transfer matrix conjugated by the displacement
-     * matrix representing the displacement vector <b>&Delta;r</b>
-     * <br>
-     * <br>
-     * &nbsp; <b>&Delta;r</b> &equiv; (<i>dx,dy,dz</i>).
-     * <br>
-     * </p>
-     * <p>
-     * <strong>NOTES</strong>: (H. SAKO)
-     * <br>
-     * &middot; added alignment error in sigma matrix
-     * </p>
-     * 
-     * @param dx    spatial displacement in <i>x</i> plane
-     * @param dy    spatial displacement in <i>y</i> plane
-     * @param dz    spatial displacement in <i>z</i> plane
-     * @param   matPhi      transfer matrix <b>&Phi;</b> to be processed
-     * 
-     * @return  transfer matrix <b>&Phi;</b> after applying displacement
-     * 
-     * @author  Hiroyuki Sako
-     * @author  Christopher K. Allen
-     * 
-     * @see PhaseMatrix
-     * @see PhaseMatrix#translation(PhaseVector)
-     * 
-     * @since Feb 20, 2009, version 2
-     */
-    protected PhaseMatrix modTransferMatrixForDisplError(double dx, double dy, double dz, PhaseMatrix matPhi) {
-        
-        if ((dx != 0)||(dy != 0)||(dz !=0)) {
-            PhaseMatrix T  = PhaseMatrix.identity();
-            PhaseMatrix Ti = PhaseMatrix.identity();
-            
-            T.setElem(IND.X,IND.HOM, -dx);
-            T.setElem(IND.Y,IND.HOM, -dy);
-            T.setElem(IND.Z,IND.HOM, -dz);
-            
-            Ti.setElem(IND.X,IND.HOM, dx);
-            Ti.setElem(IND.Y,IND.HOM, dy);
-            Ti.setElem(IND.Z,IND.HOM, dz);
-            
-            PhaseMatrix matPhiDspl = Ti.times(matPhi).times(T);
-            
-            return matPhiDspl;
-            
-        } 
-
-        return matPhi;
-
-    }
 
     /**
      * <p>

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -476,7 +476,7 @@ public abstract class Element implements IElement {
         setHardwareNodeId(strSmfId);
         setPosition(latticeElement.getCenterPosition());
 
-        AlignmentBucket alignmentBucket = latticeElement.getNode().getAlign(); 
+        AlignmentBucket alignmentBucket = latticeElement.getHardwareNode().getAlign(); 
         setAlignX(alignmentBucket.getX());
         setAlignY(alignmentBucket.getY());
         setAlignZ(alignmentBucket.getZ());

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -164,6 +164,16 @@ public abstract class Element implements IElement {
     public void setPosition(double dblPos) {
         this.dblPos = dblPos;
     }
+
+    /**
+     * Set the pivot position of the element with the containing
+     * lattice.
+     * 
+     * @param dblPivotPos    pivot position along the design trajectory (meters) 
+     */
+    public void setPivotPosition(double dblPivotPos) {
+        dblLatPivotPos = dblPivotPos;
+    }
     
     /**
      * Set the alignment parameters all at once.
@@ -393,8 +403,8 @@ public abstract class Element implements IElement {
 	    		Ti = PhaseMatrix.identity();
 	    	}
 	    	if (len > 0.) {
-	    		T = thickPitchAndYaw(T, px, py, start - dblLatPivotPos);
-	    		Ti = thickPitchAndYaw(Ti, -px, -py, start - dblLatPivotPos + len);
+	    		T = thickPitchAndYaw(T, px, py, start - getPivotPosition());
+	    		Ti = thickPitchAndYaw(Ti, -px, -py, start - getPivotPosition() + len);
 	    	}
 	    	
 	    	T = thinPitchAndYaw(T, px, py);
@@ -538,7 +548,7 @@ public abstract class Element implements IElement {
         setId( strElemId != null ? strElemId : strSmfId);
         setHardwareNodeId(strSmfId);
         setPosition(latticeElement.getCenterPosition());
-        dblLatPivotPos = latticeElement.getNode().getPosition();
+        setPivotPosition(latticeElement.getNode().getPosition());
 
         AlignmentBucket alignmentBucket = latticeElement.getNode().getAlign(); 
         setAlignX(alignmentBucket.getX());
@@ -798,6 +808,17 @@ public abstract class Element implements IElement {
      */
     public abstract double energyGain(IProbe probe, double dblLen);
 
+
+    /**
+     * Return the pivot position of the element along the design trajectory.
+     * This is the pivot position with the containing lattice.
+     * 
+     * @return  pivot position of the element (meters)
+     */
+    public double getPivotPosition() {
+        return dblLatPivotPos;
+    }
+    
     /**
      * This is a kluge to make RF gaps work, since frequency is not defined for most
      * modeling elements.  For such elements we simply return 0 phase advance.  For

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -23,6 +23,8 @@ import xal.smf.attr.AlignmentBucket;
 import xal.tools.beam.IConstants;
 import xal.tools.beam.PhaseMap;
 import xal.tools.beam.PhaseMatrix;
+import xal.tools.beam.PhaseVector;
+import xal.tools.beam.PhaseMatrix.IND;
 import xal.tools.math.r3.R3;
 
 
@@ -268,40 +270,63 @@ public abstract class Element implements IElement {
         closeElements.add(closeElem);
     }
     
+
     /**
-     * Returns the given transfer matrix adjusted by the
-     * misalignment parameters of this element.
-     *
-     * @param matPhi    a transfer matrix
+     * <h2>Add Displacement Error to Transfer Matrix</h2>
+     * <p>
+     * Method to add the effects of a spatially displaced to the
+     * beamline element represented by the given 
+     * transfer matrix.  The returned matrix is the
+     * original transfer matrix conjugated by the displacement
+     * matrix representing the displacement vector <b>&Delta;r</b>
+     * <br/>
+     * <br/>
+     * &nbsp; <b>&Delta;r</b> &equiv; (<i>dx,dy,dz</i>).
+     * <br/>
+     * </p>
+     * <p>
+     * <strong>NOTES</strong>: (H. SAKO)
+     * <br/>
+     * &middot; added alignment error in sigma matrix
+     * </p>
      * 
-     * @return          the given transfer matrix modified to contain misalignment errors
-     *
-     * @author Christopher K. Allen
-     * @since  Apr 13, 2011
+     * @param   matPhi      transfer matrix <b>&Phi;</b> to be processed
+     * 
+     * @return  transfer matrix <b>&Phi;</b> after applying displacement
+     * 
+     * @author  Hiroyuki Sako
+     * @author  Christopher K. Allen
+     * 
+     * @see PhaseMatrix
+     * @see PhaseMatrix#translation(PhaseVector)
+     * 
+     * @since Feb 20, 2009, version 2
      */
     protected PhaseMatrix applyAlignError(PhaseMatrix matPhi) {
-
-        double delx = getAlignX();
-         double dely = getAlignY();
-         double delz = getAlignZ();
+    	double dx = getAlignX();
+        double dy = getAlignY();
+        double dz = getAlignZ();
          
-         if ((delx==0)&&(dely==0)&&(delz==0)) {
-             return matPhi; // do nothing
-         }
+        if ((dx != 0)||(dy != 0)||(dz !=0)) {
+             PhaseMatrix T  = PhaseMatrix.identity();
+             PhaseMatrix Ti = PhaseMatrix.identity();
+             
+             T.setElem(IND.X,IND.HOM, -dx);
+             T.setElem(IND.Y,IND.HOM, -dy);
+             T.setElem(IND.Z,IND.HOM, -dz);
+             
+             Ti.setElem(IND.X,IND.HOM, dx);
+             Ti.setElem(IND.Y,IND.HOM, dy);
+             Ti.setElem(IND.Z,IND.HOM, dz);
+             
+             PhaseMatrix matPhiDspl = Ti.times(matPhi).times(T);
+             
+             return matPhiDspl;
+             
+        } 
 
-         PhaseMatrix T = new PhaseMatrix();
-         
-         for (int i=0;i<7;i++) {
-             T.setElem(i,i,1);
-         }
-         
-         T.setElem(0,6,-delx);
-         T.setElem(2,6,-dely);
-         T.setElem(4,6,-delz);
-         PhaseMatrix Phidx = T.inverse().times(matPhi).times(T);
-
-         return Phidx;
-     }
+        return matPhi;
+	}
      
     /**
      * <p>This method is intended to return the location of the probe within

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -19,6 +19,7 @@ import xal.model.IProbe;
 import xal.model.ModelException;
 import xal.model.alg.Tracker;
 import xal.sim.scenario.LatticeElement;
+import xal.smf.attr.AlignmentBucket;
 import xal.tools.beam.IConstants;
 import xal.tools.beam.PhaseMap;
 import xal.tools.beam.PhaseMatrix;
@@ -120,6 +121,7 @@ public abstract class Element implements IElement {
         this.cpsParent = null;
     };
     
+
     /**
      *  Set the string identifier for the element.
      *
@@ -418,6 +420,11 @@ public abstract class Element implements IElement {
         setId( strElemId != null ? strElemId : strSmfId);
         setHardwareNodeId(strSmfId);
         setPosition(latticeElement.getCenterPosition());
+        
+        AlignmentBucket alignmentBucket = latticeElement.getNode().getAlign(); 
+        setAlignX(alignmentBucket.getX());
+        setAlignY(alignmentBucket.getY());
+        setAlignZ(alignmentBucket.getZ());
         
 //        // CKA: Added to include hardware ID attribute for the new element.
 //        //   This is bound to ScenarioGenerator#collectElements(). 

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -391,17 +391,11 @@ public abstract class Element implements IElement {
 	    double py = getPhiY();
 	    double pz = getPhiZ();
 	    PhaseMatrix T = null, Ti = null;
-	    
-	    if (pz != 0.) {	    	     
-	    	T  = PhaseMatrix.rotationProduct(R3x3.newRotationZ(-pz));
-	    	Ti  = T.transpose();	    	
-	    }
-	    
+	    	    
 	    if (px != 0. || py != 0.) {
-	    	if (T == null || Ti == null) {
-	    		T = PhaseMatrix.identity();
-	    		Ti = PhaseMatrix.identity();
-	    	}
+	    	T = PhaseMatrix.identity();
+	    	Ti = PhaseMatrix.identity();
+	    	
 	    	if (len > 0.) {
 	    		T = thickPitchAndYaw(T, px, py, start - getPivotPosition());
 	    		Ti = thickPitchAndYaw(Ti, -px, -py, start - getPivotPosition() + len);
@@ -409,6 +403,16 @@ public abstract class Element implements IElement {
 	    	
 	    	T = thinPitchAndYaw(T, px, py);
 	    	Ti = thinPitchAndYaw(Ti, -px, -py);
+	    }
+	    
+	    if (pz != 0.) {
+	    	if (T == null || Ti == null) {
+	    		T = PhaseMatrix.identity();
+		    	Ti = PhaseMatrix.identity();	
+	    	}
+	    	PhaseMatrix R = PhaseMatrix.rotationProduct(R3x3.newRotationZ(-pz));
+	    	T = R.times(T);
+	    	Ti  = Ti.times(R.transpose());	    	
 	    }
 	    
 	    if (T != null) matPhi = Ti.times(matPhi).times(T);

--- a/core/src/xal/model/elem/Element.java
+++ b/core/src/xal/model/elem/Element.java
@@ -81,9 +81,6 @@ public abstract class Element implements IElement {
     //position in s (m)
     /** This is the center position of the element with the lattice - CKA */
     private double      dblPos;
-
-    private double      dblLatPivotPos;
-
     
     //sako closeElements (for fringe field calculations)
     /** 
@@ -165,15 +162,6 @@ public abstract class Element implements IElement {
         this.dblPos = dblPos;
     }
 
-    /**
-     * Set the pivot position of the element with the containing
-     * lattice.
-     * 
-     * @param dblPivotPos    pivot position along the design trajectory (meters) 
-     */
-    public void setPivotPosition(double dblPivotPos) {
-        dblLatPivotPos = dblPivotPos;
-    }
     
     /**
      * Set the alignment parameters all at once.
@@ -312,7 +300,6 @@ public abstract class Element implements IElement {
         closeElements.add(closeElem);
     }
     
-
     /**
      * <h2>Add Displacement Error to Transfer Matrix</h2>
      * <p>
@@ -370,70 +357,6 @@ public abstract class Element implements IElement {
         return matPhi;
 	}
      
-
-    /**
-	 * <h2>Add Rotation Error to Transfer Matrix</h2>
-	 * <p>
-	 * Method to add the effects of a spatial rotation to the
-	 * beamline element represented by the given 
-	 * transfer matrix.  The returned matrix is the
-	 * original transfer matrix conjugated by the rotation
-	 * matrix.
-	 * 
-	 * @param   matPhi      transfer matrix <b>&Phi;</b> to be processed
-	 * 
-	 * @return  transfer matrix <b>&Phi;</b> after applying rotations
-	 * 
-	 * @author  Ivo List
-	 */
-	protected PhaseMatrix applyRotationError(PhaseMatrix matPhi, double start, double len) {
-		double px = getPhiX();
-	    double py = getPhiY();
-	    double pz = getPhiZ();
-	    PhaseMatrix T = null, Ti = null;
-	    	    
-	    if (px != 0. || py != 0.) {
-	    	T = PhaseMatrix.identity();
-	    	Ti = PhaseMatrix.identity();
-	    	
-	    	if (len > 0.) {
-	    		T = thickPitchAndYaw(T, px, py, start - getPivotPosition());
-	    		Ti = thickPitchAndYaw(Ti, -px, -py, start - getPivotPosition() + len);
-	    	}
-	    	
-	    	T = thinPitchAndYaw(T, px, py);
-	    	Ti = thinPitchAndYaw(Ti, -px, -py);
-	    }
-	    
-	    if (pz != 0.) {
-	    	if (T == null || Ti == null) {
-	    		T = PhaseMatrix.identity();
-		    	Ti = PhaseMatrix.identity();	
-	    	}
-	    	PhaseMatrix R = PhaseMatrix.rotationProduct(R3x3.newRotationZ(-pz));
-	    	T = R.times(T);
-	    	Ti  = Ti.times(R.transpose());	    	
-	    }
-	    
-	    if (T != null) matPhi = Ti.times(matPhi).times(T);
-	    return matPhi;
-	}
-
-	// Pitch and yaw of thick elements
-	protected PhaseMatrix thickPitchAndYaw(PhaseMatrix T, double px, double py, double dist) {	 	
-    	T.setElem(IND.X,IND.HOM, -px * dist);	    	
-    	T.setElem(IND.Y,IND.HOM, -py * dist);
-    	return T;
-	}
-
-	// Shift in momentum space for pitch and yaw
-	protected PhaseMatrix thinPitchAndYaw(PhaseMatrix T, double px, double py) {
-    	T.setElem(IND.Xp,IND.HOM, -px);	    	
-    	T.setElem(IND.Yp,IND.HOM, -py);	    	
-    	
-	    return T;
-	}
-    
 
     /**
      * <p>This method is intended to return the location of the probe within
@@ -552,7 +475,6 @@ public abstract class Element implements IElement {
         setId( strElemId != null ? strElemId : strSmfId);
         setHardwareNodeId(strSmfId);
         setPosition(latticeElement.getCenterPosition());
-        setPivotPosition(latticeElement.getNode().getPosition());
 
         AlignmentBucket alignmentBucket = latticeElement.getNode().getAlign(); 
         setAlignX(alignmentBucket.getX());
@@ -811,17 +733,6 @@ public abstract class Element implements IElement {
      *  @return         the energy gain provided by this element <bold>Units: eV</bold> 
      */
     public abstract double energyGain(IProbe probe, double dblLen);
-
-
-    /**
-     * Return the pivot position of the element along the design trajectory.
-     * This is the pivot position with the containing lattice.
-     * 
-     * @return  pivot position of the element (meters)
-     */
-    public double getPivotPosition() {
-        return dblLatPivotPos;
-    }
     
     /**
      * This is a kluge to make RF gaps work, since frequency is not defined for most
@@ -892,6 +803,7 @@ public abstract class Element implements IElement {
      *  @param  os      output stream object
      */
     public void print(PrintWriter os)    {
+
 //        os.println("  Element - " + this.getId());
 //        os.println("  element type       : " + this.getType() );
 //        os.println("  element UID        : " + this.getUID() );

--- a/core/src/xal/model/elem/ElementSeq.java
+++ b/core/src/xal/model/elem/ElementSeq.java
@@ -19,6 +19,8 @@ import xal.model.IComposite;
 import xal.model.IElement;
 import xal.model.IProbe;
 import xal.model.ModelException;
+import xal.model.elem.SectionEndpoint.SectionEnd;
+import xal.model.elem.SectionEndpoint.SectionStart;
 import xal.sim.scenario.LatticeElement;
 
 
@@ -78,6 +80,9 @@ public abstract class ElementSeq implements IComposite {
     /** the current position of this composite within its parent, on demand */
     private double      dblPos;
     
+    private SectionStart sectionStart;
+    
+    private SectionEnd sectionEnd;
     
     //
     //  Structure
@@ -459,6 +464,16 @@ public abstract class ElementSeq implements IComposite {
         setId( strElemId != null ? strElemId : strSmfId);
         setHardwareNodeId(strSmfId);
 //      setId(latticeElement.getNode().getId());
+        
+        sectionStart = new SectionEndpoint.SectionStart();
+        sectionStart.setParent(this);
+        sectionStart.setId(getId()+"_SECTION_START");
+        sectionStart.initializeFrom(latticeElement);
+    	
+    	sectionEnd = new SectionEndpoint.SectionEnd();
+    	sectionEnd.setParent(this);
+        sectionEnd.setId(getId()+"_SECTION_END");
+    	sectionEnd.initializeFrom(latticeElement);
     }
     
     /**  
@@ -604,9 +619,11 @@ public abstract class ElementSeq implements IComposite {
      */
     @Override
     public void propagate(IProbe probe) throws ModelException {
+    	if (sectionStart != null) sectionStart.propagate(probe);;
         for(IComponent comp : getForwardCompList()) {
             comp.propagate(probe);
         }
+        if (sectionEnd != null) sectionEnd.propagate(probe);
     }
     
     /** 

--- a/core/src/xal/model/elem/ElementSeq.java
+++ b/core/src/xal/model/elem/ElementSeq.java
@@ -21,6 +21,7 @@ import xal.model.IProbe;
 import xal.model.ModelException;
 import xal.model.elem.SectionEndpoint.SectionEnd;
 import xal.model.elem.SectionEndpoint.SectionStart;
+import xal.model.probe.EnvelopeProbe;
 import xal.sim.scenario.LatticeElement;
 
 
@@ -465,15 +466,19 @@ public abstract class ElementSeq implements IComposite {
         setHardwareNodeId(strSmfId);
 //      setId(latticeElement.getNode().getId());
         
-        sectionStart = new SectionEndpoint.SectionStart();
-        sectionStart.setParent(this);
-        sectionStart.setId(getId()+"_SECTION_START");
-        sectionStart.initializeFrom(latticeElement);
+        if (latticeElement.isFirstSlice()) {
+	        sectionStart = new SectionEndpoint.SectionStart();
+	        sectionStart.setParent(this);
+	        sectionStart.setId(getId()+"_SECTION_START");
+	        sectionStart.initializeFrom(latticeElement);
+        }
     	
-    	sectionEnd = new SectionEndpoint.SectionEnd();
-    	sectionEnd.setParent(this);
-        sectionEnd.setId(getId()+"_SECTION_END");
-    	sectionEnd.initializeFrom(latticeElement);
+        if (latticeElement.isLastSlice()) {
+	    	sectionEnd = new SectionEndpoint.SectionEnd();
+	    	sectionEnd.setParent(this);
+	        sectionEnd.setId(getId()+"_SECTION_END");
+	    	sectionEnd.initializeFrom(latticeElement);
+        }
     }
     
     /**  

--- a/core/src/xal/model/elem/IdealMagQuad.java
+++ b/core/src/xal/model/elem/IdealMagQuad.java
@@ -262,7 +262,7 @@ public class IdealMagQuad extends ThickElectromagnet {
 			matPhi.setSubMatrix( 2, 3, 2, 3, arrF );			
 		}
 		
-	   matPhi = applyRotationError(matPhi);
+	   matPhi = applyRotationError(matPhi, probe.getPosition(), length);
 	//sako, Apply align error
 	   matPhi = applyAlignError(matPhi);
 	

--- a/core/src/xal/model/elem/IdealMagQuad.java
+++ b/core/src/xal/model/elem/IdealMagQuad.java
@@ -262,6 +262,7 @@ public class IdealMagQuad extends ThickElectromagnet {
 			matPhi.setSubMatrix( 2, 3, 2, 3, arrF );			
 		}
 		
+	   matPhi = applyRotationError(matPhi);
 	//sako, Apply align error
 	   matPhi = applyAlignError(matPhi);
 	

--- a/core/src/xal/model/elem/IdealMagQuad.java
+++ b/core/src/xal/model/elem/IdealMagQuad.java
@@ -263,9 +263,7 @@ public class IdealMagQuad extends ThickElectromagnet {
 		}
 		
 	//sako, Apply align error
-
-	   PhaseMatrix Phidx = applyAlignError(matPhi);	
-	   matPhi = Phidx;
+	   matPhi = applyAlignError(matPhi);
 	
 	   return new PhaseMap( matPhi );
    }

--- a/core/src/xal/model/elem/IdealMagQuad.java
+++ b/core/src/xal/model/elem/IdealMagQuad.java
@@ -10,15 +10,12 @@
 
 package xal.model.elem;
 
-
-
 import java.io.PrintWriter;
 
 import xal.tools.beam.PhaseMap;
 import xal.tools.beam.PhaseMatrix;
 import xal.tools.beam.optics.DriftSpace;
 import xal.tools.beam.optics.QuadrupoleLens;
-
 import xal.model.IProbe;
 
 
@@ -261,12 +258,11 @@ public class IdealMagQuad extends ThickElectromagnet {
 			matPhi.setSubMatrix( 0, 1, 0, 1, arrD );
 			matPhi.setSubMatrix( 2, 3, 2, 3, arrF );			
 		}
+				
+		// apply alignment and rotation errors
+		matPhi = applyErrors(matPhi, probe, length);			
 		
-	   matPhi = applyRotationError(matPhi, probe.getPosition(), length);
-	//sako, Apply align error
-	   matPhi = applyAlignError(matPhi);
-	
-	   return new PhaseMap( matPhi );
+	    return new PhaseMap( matPhi );
    }
     
     /*

--- a/core/src/xal/model/elem/IdealPermMagQuad.java
+++ b/core/src/xal/model/elem/IdealPermMagQuad.java
@@ -686,7 +686,7 @@ public double calcK(IProbe probe, double dblLen) {
                 matPhi.setSubMatrix(2, 3, 2, 3, arrF);
          }
         
-        matPhi = applyAlignError(matPhi);
+        matPhi = applyErrors(matPhi, probe, dblLen);
 
         return new PhaseMap(matPhi);
     }

--- a/core/src/xal/model/elem/SectionEndpoint.java
+++ b/core/src/xal/model/elem/SectionEndpoint.java
@@ -1,0 +1,134 @@
+/**
+ * 
+ */
+package xal.model.elem;
+
+import xal.model.IProbe;
+import xal.model.ModelException;
+import xal.sim.scenario.LatticeElement;
+import xal.tools.beam.PhaseMap;
+import xal.tools.beam.PhaseMatrix;
+import xal.tools.beam.PhaseVector;
+import xal.tools.math.r3.R3;
+import xal.tools.math.r3.R3x3;
+
+/**
+ * @author ilist
+ *
+ */
+public abstract class SectionEndpoint extends ThinElement {
+	protected double len;
+	
+	public SectionEndpoint(String strType) {
+		super(strType);
+	}
+	
+	/**
+	 * @see xal.model.elem.ThinElement#elapsedTime(xal.model.IProbe)
+	 */
+	@Override
+	protected double elapsedTime(IProbe probe) {		
+		return 0;
+	}
+
+	/**
+	 * @see xal.model.elem.ThinElement#energyGain(xal.model.IProbe)
+	 */
+	@Override
+	protected double energyGain(IProbe probe) {
+		return 0;
+	}
+
+	public static class SectionStart extends SectionEndpoint {
+		/** string type identifier for all SectionEndpoint objects */
+	    public static final String s_strType = "BeginSection";
+
+		public SectionStart() {
+			super(s_strType);
+		}
+		
+		/**
+		 * @see xal.model.elem.ThinElement#transferMap(xal.model.IProbe)
+		 */
+		@Override
+		protected PhaseMap transferMap(IProbe probe) throws ModelException {
+			PhaseMatrix matPhi = PhaseMatrix.identity();
+			
+			double px = getPhiX();
+		    double py = getPhiY();
+		    double pz = getPhiZ();
+	    	double dx = getAlignX();
+	        double dy = getAlignY();
+	        double dz = getAlignZ();
+	        
+		    if (px != 0. || py != 0.) {
+		    	PhaseMatrix T = PhaseMatrix.translation(new PhaseVector(px*len/2., -px, py*len/2., -py, 0., 0.));		    	
+		    	matPhi = matPhi.times(T);
+		    }
+		    
+		    if (pz != 0.) {		   
+		    	PhaseMatrix R = PhaseMatrix.rotationProduct(R3x3.newRotationZ(-pz));		    
+		    	matPhi = matPhi.times(R);
+		    }		   
+
+	        if ((dx != 0)||(dy != 0)||(dz !=0)) {
+	            PhaseMatrix T = PhaseMatrix.spatialTranslation(new R3(-dx, -dy, -dz));
+	        	matPhi = matPhi.times(T);
+	        }			
+			
+			return new PhaseMap(matPhi);
+		}
+	}
+	
+
+	public static class SectionEnd extends SectionEndpoint {
+		/** string type identifier for all SectionEndpoint objects */
+		public static final String s_strType = "EndSection";
+		
+		public SectionEnd() {
+			super(s_strType);
+		}	
+		
+		/**
+		 * @see xal.model.elem.ThinElement#transferMap(xal.model.IProbe)
+		 */
+		@Override
+		protected PhaseMap transferMap(IProbe probe) throws ModelException {
+			PhaseMatrix matPhi = PhaseMatrix.identity();
+
+			double px = getPhiX();
+		    double py = getPhiY();
+		    double pz = getPhiZ();
+			double dx = getAlignX();
+	        double dy = getAlignY();
+	        double dz = getAlignZ();
+		        
+		    if (px != 0. || py != 0.) {
+		    	PhaseMatrix T = PhaseMatrix.translation(new PhaseVector(px*len/2., px, py*len/2., py, 0., 0.)); 		    
+		    	matPhi = T.times(matPhi);
+		    }
+		    
+		    if (pz != 0.) {		   
+		    	PhaseMatrix R = PhaseMatrix.rotationProduct(R3x3.newRotationZ(pz));
+		    	matPhi = R.times(matPhi);	    		    
+		    }
+
+	        if ((dx != 0)||(dy != 0)||(dz !=0)) {
+	        	 PhaseMatrix T = PhaseMatrix.spatialTranslation(new R3(dx,dy,dz));
+	             matPhi = T.times(matPhi);
+	        } 
+			   		   
+			return new PhaseMap(matPhi);
+		}
+		
+	}
+
+	@Override
+	public void initializeFrom(LatticeElement latticeElement) {
+		// TODO Auto-generated method stub
+		super.initializeFrom(latticeElement);
+		len = latticeElement.getNode().getLength();
+	}
+}
+
+

--- a/core/src/xal/model/elem/SectionEndpoint.java
+++ b/core/src/xal/model/elem/SectionEndpoint.java
@@ -127,7 +127,7 @@ public abstract class SectionEndpoint extends ThinElement {
 	public void initializeFrom(LatticeElement latticeElement) {
 		// TODO Auto-generated method stub
 		super.initializeFrom(latticeElement);
-		len = latticeElement.getNode().getLength();
+		len = latticeElement.getHardwareNode().getLength();
 	}
 }
 

--- a/core/src/xal/model/elem/ThickElement.java
+++ b/core/src/xal/model/elem/ThickElement.java
@@ -99,9 +99,9 @@ public abstract class ThickElement extends Element {
     public void initializeFrom(LatticeElement latticeElement) {
         super.initializeFrom(latticeElement);
         setLength(latticeElement.getLength());
-        m_dblNodeLen = latticeElement.getNode().getLength();
-        firstSlice = latticeElement.getPartNr() == 0;
-        lastSlice = latticeElement.getPartNr() == latticeElement.getParts() - 1;
+        m_dblNodeLen = latticeElement.getHardwareNode().getLength();
+        firstSlice = latticeElement.isFirstSlice();
+        lastSlice = latticeElement.isLastSlice();
     }
 
     /**

--- a/core/src/xal/model/elem/ThickElement.java
+++ b/core/src/xal/model/elem/ThickElement.java
@@ -215,7 +215,7 @@ public abstract class ThickElement extends Element {
 	 * @return is this the first subslice
 	 */
     protected boolean isFirstSubslice(double position) {
-    	return firstSlice && Math.abs(position - (getPosition() - getLength()/2.)) < 1e-6;
+    	return firstSlice && Math.abs(position - (getLatticePosition() - getLength()/2.)) < 1e-6;
     }
     
     
@@ -225,7 +225,7 @@ public abstract class ThickElement extends Element {
 	 * @return is this the last sub-slice
 	 */
     protected boolean isLastSubslice(double position) {
-    	return lastSlice && Math.abs(position - (getPosition() + getLength()/2.)) < 1e-6;
+    	return lastSlice && Math.abs(position - (getLatticePosition() + getLength()/2.)) < 1e-6;
     }
  
     /**


### PR DESCRIPTION
This is an implementation of small misalignments and rotations. The code has been benchmarked against TraceWin. Misalignments and rotations work on quadrupoles as well as sections (i.e. DTLs, cavities).

The code uses data from SMF alignment bucket. It treats all data (alignments, angles) as relative to the beamline. 

Test cases on HEBT2 fail, because there are absolute rotations after bending magnets in alignment buckets.
